### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   paper:
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-latest
     name: Paper Draft
     steps:

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -5,6 +5,9 @@ on:
       - paper/**
       - .github/workflows/draft-pdf.yml
 
+permissions:
+  contents: read
+
 jobs:
   paper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xggs-dev/potamides/security/code-scanning/4](https://github.com/xggs-dev/potamides/security/code-scanning/4)

Add an explicit `permissions` block to the workflow (or to the `paper` job) with least privilege. The minimal and appropriate setting here is:

- `contents: read`

This keeps behavior unchanged while ensuring the token cannot silently inherit broader rights.  
In `.github/workflows/draft-pdf.yml`, insert `permissions:` at the workflow root (after the `on` block and before `jobs`) so it applies to all jobs by default.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
