### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/xggs-dev/potamides/security/code-scanning/2](https://github.com/xggs-dev/potamides/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml`, just below the trigger section (`on:`) and before `concurrency:`.  
Best single fix without changing functionality: set minimal read access required for checkout and general CI:

- `permissions:`
  - `contents: read`

This applies to all jobs (`pre-commit`, `checks`) unless overridden later, and satisfies CodeQL’s requirement while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
